### PR TITLE
Fix contribution license project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,5 +69,5 @@ at your option.
 ### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in Serde by you, as defined in the Apache-2.0 license, shall be
+for inclusion in pkg-config-rs by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
The text refers to Serde instead of pkg-config-rs.

Signed-off-by: Daniel Verkamp <dverkamp@chromium.org>