### PR TITLE
Default the `env_metadata` build parameter to `true`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ impl Config {
             print_system_cflags: true,
             print_system_libs: true,
             cargo_metadata: true,
-            env_metadata: false,
+            env_metadata: true,
         }
     }
 
@@ -259,7 +259,7 @@ impl Config {
 
     /// Define whether metadata should be emitted for cargo allowing to
     /// automatically rebuild when environment variables change. Defaults to
-    /// `false`.
+    /// `true`.
     pub fn env_metadata(&mut self, env_metadata: bool) -> &mut Config {
         self.env_metadata = env_metadata;
         self


### PR DESCRIPTION
`pkg-config` depends on a variety of environment variables to inform
itself on where to look information about the libraries requested. By
default the crate has chosen to not inform `cargo` about these
variables, leading to problems that usually arise from `cargo` having
incomplete understanding of the dependency information.

In particular, changing `PKG_CONFIG_PATH` variable would more likely
than not fail to rebuild various dependencies that discover their
linkage information via `pkg-config`. This behaviour is confusing.

Developers will generally not fiddle with these environment variables
however, leading to most of the crate ecosystem not setting
`env_metadata` to `true`.

This commit adjusts the default for `env_metadata` to `true` to achieve
the "correct" behaviour in the typical case. This should not actively
break any users and maybe only result in `cargo` rebuilding crates
unnecessarily in very obscure corner cases.

Fixes #104 