### PR TITLE
Pass -l:libfoo.a to linker directly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -726,7 +726,11 @@ impl Library {
                         continue;
                     }
 
-                    if statik && is_static_available(val, &system_roots, &dirs) {
+                    if val.starts_with(':') {
+                        // Pass this flag to linker directly.
+                        let meta = format!("cargo:rustc-link-arg={}{}", flag, val);
+                        config.print_metadata(&meta);
+                    } else if statik && is_static_available(val, &system_roots, &dirs) {
                         let meta = format!("rustc-link-lib=static={}", val);
                         config.print_metadata(&meta);
                     } else {


### PR DESCRIPTION
Fix #148 .