### PR TITLE
Fix compatibility with pkgconf 2.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,6 +513,7 @@ impl Config {
 
     fn command(&self, exe: OsString, name: &str, args: &[&str]) -> Command {
         let mut cmd = Command::new(exe);
+        let mut pkg_added: bool = false;
         if self.is_static(name) {
             cmd.arg("--static");
         }
@@ -533,24 +534,30 @@ impl Config {
         if self.print_system_cflags {
             cmd.env("PKG_CONFIG_ALLOW_SYSTEM_CFLAGS", "1");
         }
-        cmd.arg(name);
         match self.min_version {
             Bound::Included(ref version) => {
                 cmd.arg(&format!("{} >= {}", name, version));
+                pkg_added = true;
             }
             Bound::Excluded(ref version) => {
                 cmd.arg(&format!("{} > {}", name, version));
+                pkg_added = true;
             }
             _ => (),
         }
         match self.max_version {
             Bound::Included(ref version) => {
                 cmd.arg(&format!("{} <= {}", name, version));
+                pkg_added = true;
             }
             Bound::Excluded(ref version) => {
                 cmd.arg(&format!("{} < {}", name, version));
+                pkg_added = true;
             }
             _ => (),
+        }
+        if !pkg_added {
+            cmd.arg(name);
         }
         cmd
     }


### PR DESCRIPTION
pkgconf 2.0 no longer accepts --modversion calls specifying multiple modules or modules specified multiple times, such as what pkg-config-rs does when checking for versioned dependencies, such as

pkg-config --modversion libxyz "libxyz >= 2.0.0"

(which should be just
pkg-config --modversion "libxyz >= 2.0.0").

The correct call works with both old and new pkg-config.