### PR TITLE
Fix Windows static library detection and usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -905,6 +905,10 @@ impl Library {
                         iter.next().map(|s| s.to_owned()),
                     );
                 }
+                "-u" => {
+                    let meta = format!("rustc-link-arg=-Wl,-u,{}", val);
+                    config.print_metadata(&meta);
+                }
                 _ => {}
             }
         }
@@ -929,6 +933,12 @@ impl Library {
                 "-isystem" | "-iquote" | "-idirafter" => {
                     if let Some(inc) = iter.next() {
                         self.include_paths.push(PathBuf::from(inc));
+                    }
+                }
+                "-undefined" | "--undefined" => {
+                    if let Some(symbol) = iter.next() {
+                        let meta = format!("rustc-link-arg=-Wl,{},{}", part, symbol);
+                        config.print_metadata(&meta);
                     }
                 }
                 _ => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1004,10 +1004,19 @@ fn envify(name: &str) -> String {
 
 /// System libraries should only be linked dynamically
 fn is_static_available(name: &str, system_roots: &[PathBuf], dirs: &[PathBuf]) -> bool {
-    let libname = format!("lib{}.a", name);
+    let libnames = {
+        let mut names = vec![format!("lib{}.a", name)];
+
+        if cfg!(target_os = "windows") {
+            names.push(format!("{}.lib", name));
+        }
+
+        names
+    };
 
     dirs.iter().any(|dir| {
-        !system_roots.iter().any(|sys| dir.starts_with(sys)) && dir.join(&libname).exists()
+        let library_exists = libnames.iter().any(|libname| dir.join(&libname).exists());
+        library_exists && !system_roots.iter().any(|sys| dir.starts_with(sys))
     })
 }
 


### PR DESCRIPTION
Hi!

This PR is intended to address some issues found when attempting to link to static libraries under Windows.

- `-Wl,--undefined` flags were silently skipped.
- `is_static_available` does not consider Windows SDK or CRT bindings.
- Allows using the `.a` and `.dll.a` convention for MSVC as well, thus letting Meson-built libraries be used.

CC @nirbheek