### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,10 @@ jobs:
           - beta
           - nightly
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        default: true
-        profile: minimal
     - run: rustup component add rustfmt-preview
     - name: cargo fmt --all -- --check if stable
       run: |


### PR DESCRIPTION
The following updates are performed:
* update [`actions/checkout`](https://github.com/actions/checkout) to v4
* replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) `actions-rs/toolchain` by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)

Still using the outdated / unmaintained actions will generate several warnings in CI runs, for example in https://github.com/rust-lang/pkg-config-rs/actions/runs/7556790008:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions-rs/toolchain@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

The PR will get rid of those warnings.