### PR TITLE
Use `pkgconf` instead of `pkg-config` for brew builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,7 @@ impl fmt::Display for Error {
                     io::ErrorKind::NotFound => {
                         let crate_name =
                             std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| "sys".to_owned());
-                        let instructions = if cfg!(target_os = "macos") || cfg!(target_os = "ios") {
+                        let instructions = if cfg!(target_os = "macos") {
                             "Try `brew install pkgconf` if you have Homebrew.\n"
                         } else if cfg!(unix) {
                             "Try `apt install pkg-config`, or `yum install pkg-config`,\n\

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,7 +286,7 @@ impl fmt::Display for Error {
                         let crate_name =
                             std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| "sys".to_owned());
                         let instructions = if cfg!(target_os = "macos") || cfg!(target_os = "ios") {
-                            "Try `brew install pkg-config` if you have Homebrew.\n"
+                            "Try `brew install pkgconf` if you have Homebrew.\n"
                         } else if cfg!(unix) {
                             "Try `apt install pkg-config`, or `yum install pkg-config`,\n\
                             or `pkg install pkg-config`, or `apk add pkgconfig` \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ impl fmt::Display for Error {
                         } else if cfg!(target_os = "ios") {
                             "" // iOS cross-compilation requires a custom setup, no easy fix
                         } else if cfg!(unix) {
-                            "Try `apt install pkg-config`, or `yum install pkg-config`,\n\
+                            "Try `apt install pkg-config`, or `yum install pkg-config`, or `brew install pkgconf`\n\
                             or `pkg install pkg-config`, or `apk add pkgconfig` \
                             depending on your distribution.\n"
                         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,6 +287,8 @@ impl fmt::Display for Error {
                             std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| "sys".to_owned());
                         let instructions = if cfg!(target_os = "macos") {
                             "Try `brew install pkgconf` if you have Homebrew.\n"
+                        } else if cfg!(target_os = "ios") {
+                            "" // iOS cross-compilation requires a custom setup, no easy fix
                         } else if cfg!(unix) {
                             "Try `apt install pkg-config`, or `yum install pkg-config`,\n\
                             or `pkg install pkg-config`, or `apk add pkgconfig` \


### PR DESCRIPTION
On homebrew side, we have migrated to use `pkgconf` for all core formulae and now have everyone use `pkgconf` rather than `pkg-config`.

- https://github.com/Homebrew/brew/pull/18843