### PR TITLE
Fix static linking against libbsd on ubuntu

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1052,7 +1052,7 @@ fn envify(name: &str) -> String {
 /// System libraries should only be linked dynamically
 fn is_static_available(name: &str, system_roots: &[PathBuf], dirs: &[PathBuf]) -> bool {
     let libnames = {
-        let mut names = vec![format!("lib{}.a", name)];
+        let mut names = vec![format!("lib{}.a", name), format!("{}.a", name)];
 
         if cfg!(target_os = "windows") {
             names.push(format!("{}.lib", name));


### PR DESCRIPTION
I noticed that I was getting a shared dependency on `libbsd.so` from a package using pkg-config recently, and it seems to be due to this changed line; the Ubuntu libbsd pkg-config name is `libbsd`, so previously `is_static_available` would look for `liblibbsd`.

At a glance, it seems like a few different libraries have `libfoo.pc` as libbsd does, so I’ve proposed the following change, just adding `{}.a` to the list after `lib{}.a`.