### PR TITLE
fix: add pkg-config stderr to Rust error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,6 +351,18 @@ impl fmt::Display for Error {
                 // Give the command run so users can reproduce the error
                 writeln!(f, "> {}\n", command)?;
 
+                // Show pkg-config's own error output, this often contains the
+                // actual reason for the failure (e.g. a missing transitive
+                // dependency) which is more specific than our generic message.
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                if !stderr.is_empty() {
+                    writeln!(f, "pkg-config output:")?;
+                    for line in stderr.lines() {
+                        writeln!(f, "  {}", line)?;
+                    }
+                    writeln!(f)?;
+                }
+
                 // Explain how it was caused
                 writeln!(
                     f,


### PR DESCRIPTION
Fixes https://github.com/rust-lang/pkg-config-rs/issues/174

See for example this case where `glib.pc` requires `zlib.pc`. While the CLI reports that correctly, the Rust error doesn't mention it at all. With this change the CLI error is included:

```diff
 pkg-config exited with status code 1
 > PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags gio-2.0

+pkg-config output:
+  Package zlib was not found in the pkg-config search path.
+  Perhaps you should add the directory containing `zlib.pc'
+  to the PKG_CONFIG_PATH environment variable
+  Package 'zlib', required by 'gio-2.0', not found
+
 The system library `gio-2.0` required by crate `probe-patched` was not found.
 The file `gio-2.0.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.
 PKG_CONFIG_PATH contains the following:
     - $PREFIX/lib/pkgconfig
 HINT: you may need to install a package such as gio-2.0, gio-2.0-dev or gio-2.0-devel.
```